### PR TITLE
Support files in subfolders

### DIFF
--- a/src/DukDebugger.ts
+++ b/src/DukDebugger.ts
@@ -1964,7 +1964,7 @@ class DukDebugSession extends DebugSession
         let name    = Path.basename( path );
 
         // Grab the relative path under the root if this is located there, or just keep the full path if it's not
-        let pathUnderRoot = Path.dirname(this.getSourceNameByPath(path) || path);
+        let pathUnderRoot = Path.dirname(this.getSourceNameByPath(path) || "");
 
         if( !this._sourceMaps )
             return this.mapSourceFile( Path.join(pathUnderRoot, name) );
@@ -1977,15 +1977,14 @@ class DukDebugSession extends DebugSession
         
         let src:SourceFile = null;
 
-        let outDirToScan = this._outDir;
-        
-        // Next construct the folder to scan by combining the path coming in with the out directory.  The
-        // path coming in may point to a subfolder under "RootPath"
-        outDirToScan = Path.join(outDirToScan, pathUnderRoot);
-        this.dbgLog("TSH - Scanning directory: " + outDirToScan);
-
         // If we still haven't found anything,
         // we try to map all the source files in the outDir
+        
+        // Let's construct the folder to scan by combining the path coming in with the out directory.  The
+        // path coming in may point to a subfolder under "rootPath" so this will ensure that we are looking in
+        // the right directory
+        let outDirToScan = Path.join(this._outDir, pathUnderRoot);
+        
         let files:string[] = FS.readdirSync( outDirToScan );
 
         for( let i = 0; i < files.length; i++ )

--- a/src/DukDebugger.ts
+++ b/src/DukDebugger.ts
@@ -266,7 +266,7 @@ class SourceFile
         {
             let pos = this.srcMap.generatedPositionFor( absSourcePath, line, 0, Bias.LEAST_UPPER_BOUND );
             
-            if( pos.line != null )
+            if( pos && pos.line != null )
             {
                 return {
                     path     : this.path,
@@ -805,7 +805,7 @@ class DukDebugSession extends DebugSession
                 line = pos.line;
             }
             else
-                generatedName = this.getSourceNameByPath(args.source.path) || args.source.name;
+                generatedName = this.getSourceNameByPath( args.source.path ) || args.source.name;
 
             if( !generatedName )
             {
@@ -1940,7 +1940,11 @@ class DukDebugSession extends DebugSession
                 let srcMap = src.srcMap;
                 for( let i = 0; i < srcMap._sources.length; i++ )
                 {
-                    let srcPath = Path.normalize( Path.join( this._sourceRoot, srcMap._sources[i] ) );
+                    let srcPath = srcMap._sources[i];
+                    if( !Path.isAbsolute( srcPath ) )
+                        srcPath = Path.join( this._sourceRoot, srcPath );
+                    
+                    srcPath = Path.normalize( srcPath );
                     this._sourceToGen[srcPath] = src;
                 }
             }
@@ -1958,13 +1962,14 @@ class DukDebugSession extends DebugSession
     // the source maps of all the generated files 
     // and attempts to find the file in them
     //-----------------------------------------------------------
-    private unmapSourceFile( path:string ) : SourceFile
+    private unmapSourceFile( path:string ):SourceFile
     {
         path        = Path.normalize( path );
         let name    = Path.basename( path );
 
-        // Grab the relative path under the root if this is located there, or just keep the full path if it's not
-        let pathUnderRoot = Path.dirname(this.getSourceNameByPath(path) || "");
+        // Grab the relative path under the root if this is located there,
+        // or just keep the full path if it's not
+        let pathUnderRoot = Path.dirname( this.getSourceNameByPath( path ) || "" );
 
         if( !this._sourceMaps )
             return this.mapSourceFile( Path.join(pathUnderRoot, name) );
@@ -1980,29 +1985,45 @@ class DukDebugSession extends DebugSession
         // If we still haven't found anything,
         // we try to map all the source files in the outDir
         
-        // Let's construct the folder to scan by combining the path coming in with the out directory.  The
-        // path coming in may point to a subfolder under "rootPath" so this will ensure that we are looking in
-        // the right directory
-        let outDirToScan = Path.join(this._outDir, pathUnderRoot);
-        
-        let files:string[] = FS.readdirSync( outDirToScan );
+        const scanDir = ( dirPath:string, rootPath:string ) => {
+           
+            // In case the directory doesn't exsist
+            var files:string[];
+            try { files = FS.readdirSync( dirPath ); }
+            catch ( err ) {
+                return;
+            }
 
-        for( let i = 0; i < files.length; i++ )
-        {
-            let f:string = files[i];
-            
             // Ignore non-js files
-            if( f.toLowerCase().lastIndexOf(".js") != f.length - ".js".length )
-                continue;
+            files = files.filter( f => Path.extname( f ).toLocaleLowerCase() === ".js" );
 
-            var stat = FS.lstatSync( Path.join( outDirToScan, f ) );
-            if( stat.isDirectory() )        // Ignore dirs, shallow search
-                continue;
-            
-            src = this.mapSourceFile(Path.join(pathUnderRoot, f));
-            if( src )
-                return src;
-        }
+            for( let i = 0; i < files.length; i++ )
+            {
+                let f:string = files[i];
+
+                var stat = FS.lstatSync( Path.join( dirPath, f ) );
+                if( stat.isDirectory() )        // Ignore dirs, shallow search
+                    continue;
+                
+                src = this.mapSourceFile( Path.join( rootPath, f ) );
+                if( src )
+                    return src;
+            }
+        };
+
+        
+        // Let's construct the folder to scan by combining the path
+        // coming in with the out directory.  The
+        // path coming in may point to a subfolder under "rootPath" 
+        // so this will ensure that we are looking in the right directory
+        let outDirToScan = Path.join( this._outDir, pathUnderRoot );
+
+        // For concatenated transpiled files, the output folder here may not exsist,
+        // since the output is a single file. Therefore no such other directory or 
+        // file mathching the source folder structure may exsist in the output directory.
+        // So we first attempt to scan the path matching the source root structure, then
+        // a flat scan of the outDir.
+        return scanDir( outDirToScan, pathUnderRoot ) || scanDir( this._outDir, "" );
     }
     
     //-----------------------------------------------------------


### PR DESCRIPTION
This PR updates the debugger to allow for files in subfolders under ```sourceRoot``` and ```outDir```.  In our usage of duktape, we are using the ```require``` addon to be able to pull in multiple modules.  When these modules are loaded, the ```filename``` attribute on the module definition contains the relative path from the source root + filename which will get passed through to the listening debugger.

When the debugger sets or gets triggered on a breakpoint, that filename is mapped to the corresponding local file.  If the filename contains relative path information, it will navigate to the appropriate subdirectory to pull the file.  If the filename comes in bare, then it behaves like the current system and just looks in the root of these directories.