### PR TITLE
Paths to source files in sourceMaps are not resolved correctly. unmapSourceFile() returns wrong SourceFile

### DIFF
--- a/src/DukDebugger.ts
+++ b/src/DukDebugger.ts
@@ -1965,8 +1965,12 @@ class DukDebugSession extends DebugSession
                 for( let i = 0; i < srcMap._sources.length; i++ )
                 {
                     let srcPath = srcMap._sources[i];
-                    if( !Path.isAbsolute( srcPath ) )
-                        srcPath = Path.join( this._sourceRoot, srcPath );
+                    if( !Path.isAbsolute( srcPath ) ) 
+                    {
+                        // According to https://sourcemaps.info/spec.html#h.75yo6yoyk7x5 :
+                        // if the sources are not absolute URLs after prepending of the “sourceRoot”, the sources are resolved relative to the SourceMap
+                        srcPath = Path.resolve(Path.dirname(this.normPath(Path.join(this._outDir, name))), srcPath);
+                    }
                     
                     srcPath = Path.normalize( srcPath );
                     this._sourceToGen[srcPath] = src;

--- a/src/DukDebugger.ts
+++ b/src/DukDebugger.ts
@@ -2033,9 +2033,7 @@ class DukDebugSession extends DebugSession
                 if( stat.isDirectory() )        // Ignore dirs, shallow search
                     continue;
                 
-                src = this.mapSourceFile( Path.join( rootPath, f ) );
-                if( src )
-                    return src;
+                this.mapSourceFile( Path.join( rootPath, f ) );
             }
         };
 
@@ -2051,7 +2049,10 @@ class DukDebugSession extends DebugSession
         // file mathching the source folder structure may exsist in the output directory.
         // So we first attempt to scan the path matching the source root structure, then
         // a flat scan of the outDir.
-        return scanDir( outDirToScan, pathUnderRoot ) || scanDir( this._outDir, "" );
+        scanDir( outDirToScan, pathUnderRoot );
+        scanDir( this._outDir, "" );
+
+        return src2gen[path];
     }
     
     //-----------------------------------------------------------


### PR DESCRIPTION
This PR solves these two issues:
1) Paths to source files in sourceMaps are not resolved correctly if they are relative (not absolute).
2) In unmapSourceFile(), scanDir() does not map all the source files in the outDir as the comment states:
        // If we still haven't found anything,
        // we try to map all the source files in the outDir
Also it returns the first mapped file instead of the correct one.