### PR TITLE
Multiple local source roots

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Create a new launch.json configuration file and configure the address and port t
             "address"     : "localhost",
             "port"        : 9091,
             
-            "localRoot"   : "${workspaceRoot}",
+            "localRoots"  : [ "${workspaceRoot}" ],
             
             "sourceMaps"  : true,
             "outDir"      : "${workspaceRoot}/bin"

--- a/package.json
+++ b/package.json
@@ -131,6 +131,14 @@
                                 "description": "Automatically stop program after launch.",
                                 "default": true
                             },
+                            "localRoot": {
+                                "type": [
+                                    "string",
+                                    "null"
+                                ],
+                                "description": "The local source root that corresponds to the remote root path.",
+                                "default": null
+                            },
                             "localRoots": {
                                 "type": [
                                     "array",

--- a/package.json
+++ b/package.json
@@ -131,12 +131,15 @@
                                 "description": "Automatically stop program after launch.",
                                 "default": true
                             },
-                            "localRoot": {
+                            "localRoots": {
                                 "type": [
-                                    "string",
+                                    "array",
                                     "null"
                                 ],
-                                "description": "The local source root that corresponds to the 'remoteRoot'.",
+                                "items": {
+                                    "type": "string"
+                                },
+                                "description": "The local source root paths that correspond to the remote root paths.",
                                 "default": null
                             },
                             "debugLog": {
@@ -159,7 +162,9 @@
                         "request": "attach",
                         "address": "localhost",
                         "port": 9091,
-                        "localRoot": "${workspaceRoot}",
+                        "localRoots": [
+                            "${workspaceRoot}"
+                        ],
                         "sourceMaps": false,
                         "outDir": null,
                         "stopOnEntry": false,
@@ -176,7 +181,9 @@
                             "request": "attach",
                             "address": "localhost",
                             "port": 9091,
-                            "localRoot": "^\"\\${workspaceRoot}\"",
+                            "localRoots": [
+                                "^\"\\${workspaceRoot}\""
+                            ],
                             "sourceMaps": false,
                             "outDir": null,
                             "stopOnEntry": false,

--- a/src/DukDbgProtocol.ts
+++ b/src/DukDbgProtocol.ts
@@ -288,7 +288,7 @@ export class DukGetCallStackResponse extends DukResponse
         let len = ( msg.length - 2 );
         if( len === 0 )
         {
-            this.callStack = new DukCallStackEntry[0];
+            this.callStack = new Array<DukCallStackEntry>();
         }
         else
         {

--- a/src/DukDebugger.ts
+++ b/src/DukDebugger.ts
@@ -486,7 +486,10 @@ export class DukDebugSession extends DebugSession
             this._expectingBreak = "Exception";
 
             const sendEvent = function () {
-                const source: Source = new Source(e.fileName, Path.resolve(this._outDir, e.fileName));
+                const sourceFile: SourceFile = this.mapSourceFile( e.fileName );
+                const source: Source = sourceFile ?
+                    new Source( sourceFile.name, sourceFile.path ) :
+                    new Source( e.fileName, Path.resolve( this._outDir, e.fileName ) );
                 const outputEventOptions = {
                     source: source,
                     line: e.lineNumber,

--- a/src/DukDebugger.ts
+++ b/src/DukDebugger.ts
@@ -2335,6 +2335,7 @@ export class DukDebugSession extends DebugSession
 
         fpath = Path.normalize( fpath );
         fpath = fpath.replace(/\\/g, '/');
+        fpath = fpath.replace(/^[A-Z]:\//, match => match.toLowerCase());
         return fpath;
     }
 

--- a/src/DukDebugger.ts
+++ b/src/DukDebugger.ts
@@ -104,6 +104,8 @@ export interface AttachRequestArguments extends DebugProtocol.AttachRequestArgum
     /** Node's root directory. */
     remoteRoot?: string;
     /** VS Code's root directory. */
+    localRoot?: string;
+    /** VS Code's root directories. */
     localRoots?: string[];
 }
 
@@ -673,10 +675,10 @@ export class DukDebugSession extends DebugSession
     {
         this.dbgLog( "[FE] attachRequest" );
 
-        if( !args.localRoots || args.localRoots.length === 0 )
+        if( ( !args.localRoot || args.localRoot === "" ) && ( !args.localRoots || args.localRoots.length === 0 ) )
         {
             this.sendErrorResponse( response, 0,
-                "Must specify `localRoots`" );
+                "Must specify `localRoot` or `localRoots`" );
             return;
         }
 
@@ -689,7 +691,16 @@ export class DukDebugSession extends DebugSession
 
         this._args          = args;
         this._launchType    = LaunchType.Attach;
-        this._sourceRoots   = args.localRoots.map(path => { return this.normPath( path ) });
+        this._sourceRoots   = new Array<string>();
+
+        if( args.localRoot ) {
+            this._sourceRoots = this._sourceRoots.concat( this.normPath( args.localRoot ) );
+        }
+
+        if( args.localRoots ) {
+            this._sourceRoots = this._sourceRoots.concat( args.localRoots.map( path => { return this.normPath( path ) } ) );
+        }
+
         this._outDir        = this.normPath( args.outDir     );
         this._dbgLog        = args.debugLog || false;
 


### PR DESCRIPTION
These changes allow to specify multiple source paths (much like `source-dirs` option in `duk_debug.js`) by providing `localRoots` option instead of `localRoot`. This makes possible to have multiple remote source root paths (which is a must-have thing for the project I'm working on).