### PR TITLE
getSourceNameByPath(): Fix first character cut-off

### DIFF
--- a/src/DukDebugger.ts
+++ b/src/DukDebugger.ts
@@ -2163,7 +2163,7 @@ export class DukDebugSession extends DebugSession {
 
         for (let rpath of this._sourceRoots) {
             if (fpath.indexOf(rpath) === 0) {
-                const sourceName = fpath.substr(rpath.length + 1);
+                const sourceName = fpath.substr(rpath.length);
                 this.dbgLog(`[getSourceNameByPath] Path found in source root '${rpath}' source name: ${sourceName}`);
                 return sourceName;
             }


### PR DESCRIPTION
Hello, first character is being cut off in getSourceNameByPath() function.

Please merge this fix.